### PR TITLE
(feat: 페이지 레이아웃 수정, 댓글 기능 추가)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,19 +1,6 @@
 import './App.css';
-import { Route, Routes } from 'react-router-dom';
-import Main from "./pages/Main";
-import SignUpPage from 'pages/SignUpPage';
-import LoginPage from 'pages/LoginPage';
 import Cookies from 'js-cookie';
 import { useState, useEffect } from 'react';
-import Logout from 'components/member/Logout';
-import PetFormPage from 'pages/PetFormPage';
-import PetEditPage from 'pages/PetEditPage';
-import MyPage from 'pages/MyPage';
-import BoardListPage from './components/board/BoardList';
-import BoardCreateForm from 'pages/BoardCreatePage'
-import BoardModifyForm from 'pages/BoardModifyPage'
-import BoardDetail from 'pages/BoardDetailPage'
-import { BrowserRouter } from 'react-router-dom';
 import { HelmetProvider } from 'react-helmet-async';
 // routes
 import Router from './routes';

--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ import Main from "./pages/Main";
 import SignUpPage from 'pages/SignUpPage';
 import LoginPage from 'pages/LoginPage';
 import Cookies from 'js-cookie';
-import {useState, useEffect} from 'react';
+import { useState, useEffect } from 'react';
 import Logout from 'components/member/Logout';
 import PetFormPage from 'pages/PetFormPage';
 import PetEditPage from 'pages/PetEditPage';
@@ -22,6 +22,7 @@ import ThemeProvider from './theme';
 // components
 import { StyledChart } from './components/chart';
 import ScrollToTop from './components/scroll-to-top';
+import { RecoilRoot } from 'recoil';
 
 function App() {
 
@@ -38,15 +39,17 @@ function App() {
   return (
 
     <div>
-      <HelmetProvider>
-        <ThemeProvider>
-          <ScrollToTop />
-          <StyledChart />
-          <Router />
-        </ThemeProvider>
-      </HelmetProvider>
+      <RecoilRoot>
+        <HelmetProvider>
+          <ThemeProvider>
+            <ScrollToTop />
+            <StyledChart />
+            <Router />
+          </ThemeProvider>
+        </HelmetProvider>
+      </RecoilRoot>
     </div>
-    
+
   );
 }
 

--- a/src/components/board/BoardCreateForm.tsx
+++ b/src/components/board/BoardCreateForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Table, TableContainer, TableRow, TableCell, MenuItem, FormControl, Select, TextField, Typography, Box, Button, Divider} from '@mui/material';
+import { Table, TableContainer, TableRow, TableCell, MenuItem, FormControl, Select, TextField, Typography, Box, Button, Divider, Paper} from '@mui/material';
 import BoardImageUploader from 'components/board/boardImageUploader'
 import api from 'lib/api';
 import boardRequestDto from 'dto/boardRequestDto';
@@ -70,7 +70,7 @@ export default function BoardForm() {
       </Typography>
       <Divider />
       <TableContainer sx={{ display: 'flex', justifyContent: 'center', my: 8 }}>
-        <Table sx={{ minWidth: 200, width: 1000 }}>
+        <Table sx={{ minWidth: 200, width: 1000, backgroundColor:'white', border: '1px solid #DCDCDC', borderRadius: 5}}>
           <TableRow>
             <TableCell>카테고리</TableCell>
             <TableCell align="left">

--- a/src/components/board/BoardDetail.tsx
+++ b/src/components/board/BoardDetail.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import moment from 'moment';
-import { Link, useParams,useNavigate} from 'react-router-dom';
+import { Link, useParams, useNavigate } from 'react-router-dom';
 import boardResponseDto from 'dto/boardResponseDto';
 import api from 'lib/api';
 import Cookies from 'js-cookie';
-import { Button, TableContainer, Table, TableBody, TableCell, TableRow, Paper, Typography, Divider } from '@mui/material';
+import { Button, TableContainer, Table, TableBody, TableCell, TableRow, Paper, Typography, Divider, Container, Box, Stack } from '@mui/material';
+import Reply from './Reply';
 
 function BoardDetail(): JSX.Element {
   const [board, setBoard] = useState<boardResponseDto | null>();
@@ -22,19 +23,19 @@ function BoardDetail(): JSX.Element {
 
   const handleDeleteSubmit = async (e) => {
     e.preventDefault();
-    const shouldDelete = window.confirm('정말로 삭제하시겠습니까?'); 
-  
+    const shouldDelete = window.confirm('정말로 삭제하시겠습니까?');
+
     if (shouldDelete) {
       const token = Cookies.get('key');
       const headers = {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${token}`,
       };
-  
+
       const response = await api.delete(`http://localhost:7777/api/board/delete/${boardId}`, { headers });
       if (response.data.status === 200) {
         alert('게시글이 삭제되었습니다.');
-        
+
       } else {
         alert(`${response.data.message}`);
       }
@@ -52,57 +53,68 @@ function BoardDetail(): JSX.Element {
 
   return (
     <div>
-      <Button component={Link} to={`/board/modify/${boardId}`} variant="contained">
-        글 수정
-      </Button>
-      <Button variant="contained" onClick={handleDeleteSubmit}>
-        글 삭제
-      </Button>
-      {board ? (
-        <TableContainer component={Paper}>
-          <Table>
-            <TableBody>
-              <TableRow>
-                <TableCell>
-                  <Typography sx={{ padding:1, color: 'grey', display: 'flex', justifyContent: 'left' }}> 
-                  {moment(board.moddate).format('YYYY-MM-DD HH:mm')}
-                  </Typography>
-                  <Typography sx={{display: 'flex', justifyContent: 'left', padding:1}}>[{(() => {
-                switch (board.category) {
-                  case 'walk-with':
-                    return '산책가요';
-                  case 'show-off':
-                    return '동물자랑';
-                  case 'sitter':
-                    return '시터공고';
-                  default:
-                    return board.category;
-                }
-              })()}] {board.title}  
-                  </Typography>
-                  <Typography sx={{display: 'flex', justifyContent: 'left', padding:1}}>
-                    👤 {board.writerNickname}
-                  </Typography>
-                  <Divider sx={{margin:3}}/>
-                  {board.image !== '' && <div style={{ display: 'flex', justifyContent: 'center', margin: '10px 0' }}>
-                    <img src={board.image} alt={`${board.title}`} style={{ maxWidth: '100%' }} /></div>}
-                  <Typography sx={{display: 'flex', justifyContent: 'center', margin:5}}>
-                    {board.content}
-                  </Typography>
-                  <Typography sx={{display: 'flex', justifyContent: 'right', padding:1}}>
-                  👀 {board.clickCnt}
-                  </Typography>
-                </TableCell>
-              </TableRow>
-            </TableBody>
-          </Table>
-        </TableContainer>
-      ) : (
-        <div>Loading...</div>
-      )}
-      <Button variant="contained" onClick={goBackToList}> 
-        목록으로 돌아가기
-      </Button>
+      <Container component="main" maxWidth="lg" >
+        <Button component={Link} to={`/board/modify/${boardId}`} variant="contained">
+          글 수정
+        </Button>
+        <Button variant="contained" onClick={handleDeleteSubmit}>
+          글 삭제
+        </Button>
+        {board ? (
+          <>
+            <Box component={Paper} sx={{ border: '1px solid #DCDCDC', borderRadius: 5, }} >
+              <TableContainer >
+                <Table>
+                  <TableBody>
+                    <TableRow>
+                      <TableCell>
+                        <Typography sx={{ padding: 1, color: 'grey', display: 'flex', justifyContent: 'left' }}>
+                          {moment(board.moddate).format('YYYY-MM-DD HH:mm')}
+                        </Typography>
+                        <Typography sx={{ display: 'flex', justifyContent: 'left', padding: 1 }}>[{(() => {
+                          switch (board.category) {
+                            case 'walk-with':
+                              return '산책가요';
+                            case 'show-off':
+                              return '동물자랑';
+                            case 'sitter':
+                              return '시터공고';
+                            default:
+                              return board.category;
+                          }
+                        })()}] {board.title}
+                        </Typography>
+                        <Typography sx={{ display: 'flex', justifyContent: 'left', padding: 1 }}>
+                          👤 {board.writerNickname}
+                        </Typography>
+                        <Divider sx={{ margin: 3 }} />
+                        {board.image !== '' && <div style={{ display: 'flex', justifyContent: 'center', margin: '10px 0' }}>
+                          <img src={board.image} alt={`${board.title}`} style={{ maxWidth: '100%' }} /></div>}
+                        <Typography sx={{ display: 'flex', justifyContent: 'center', margin: 5 }}>
+                          {board.content}
+                        </Typography>
+                        <Typography sx={{ display: 'flex', justifyContent: 'right', padding: 1 }}>
+                          👀 {board.clickCnt}
+                        </Typography>
+                      </TableCell>
+                    </TableRow>
+                  </TableBody>
+                </Table>
+              </TableContainer>
+
+              <Reply /> 
+
+
+              </Box>
+
+            </>
+            ) : (
+            <div>Loading...</div>
+        )}
+            <Button variant="contained" onClick={goBackToList}>
+              목록으로 돌아가기
+            </Button>
+          </Container>
     </div>
   );
 }

--- a/src/components/board/BoardList.tsx
+++ b/src/components/board/BoardList.tsx
@@ -5,7 +5,7 @@ import { useParams, Link, useNavigate } from 'react-router-dom';
 import boardResponseDto from 'dto/boardResponseDto';
 import api from 'lib/api';
 import Typography from '@mui/material/Typography';
-import { Divider, Button, Select, MenuItem } from '@mui/material';
+import { Divider, Button, Select, MenuItem, Container } from '@mui/material';
 import Paging from './Paging';
 import './styles/ListStyle.css';
 import SearchBar from './SeachBar';
@@ -62,87 +62,90 @@ function BoardList(): JSX.Element {
 
   return (
     <>
-      <Typography
-        sx={{
-          width: '100%',
-          typography: 'h3',
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          fontFamily: 'SDSamliphopangche_Basic',
-          padding: 3,
-        }}
-      >
-        우리 동네 게시판
-      </Typography>
-      <Divider />
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          padding: '0 1rem',
-        }}
-      >
-        <Select
-          labelId="select-category"
-          id="select-category"
-          value={selectedCategory}
-          onChange={handleCategoryChange}
-          displayEmpty
-          inputProps={{ 'aria-label': 'Without label' }}
+      <Container component="main" maxWidth="xl" >
+
+        <Typography
+          sx={{
+            width: '100%',
+            typography: 'h3',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            fontFamily: 'SDSamliphopangche_Basic',
+          }}
         >
-          <MenuItem value="all">전체</MenuItem>
-          <MenuItem value="walk-with">산책가요</MenuItem>
-          <MenuItem value="show-off">동물자랑</MenuItem>
-          <MenuItem value="sitter">시터공고</MenuItem>
-        </Select>
-        <Button variant="contained" sx={{ mt: 3, mb: 2, mx: 0.5, color: 'white' }} >
-          
-          <Link to={`/board/create`}>글쓰기</Link>
-        </Button>
-      </div>
-      {boardList === null || status === 204 ? (
-        <div className="crying-image-container">
-          <img
-            src="https://bys-petgoorm.s3.ap-northeast-2.amazonaws.com/pet-profile/202309112022_nbiuirc51.jpeg"
-            alt="🥲"
-            className="crying-image"
-          />
-          <p className="text-overlay">게시물이 없어요!</p>
+          우리 동네 게시판
+        </Typography>
+        <Divider />
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            padding: '0 1rem',
+            
+          }}
+        >
+          <Select
+            labelId="select-category"
+            id="select-category"
+            value={selectedCategory}
+            onChange={handleCategoryChange}
+            displayEmpty
+            inputProps={{ 'aria-label': 'Without label' }}
+          >
+            <MenuItem value="all">전체</MenuItem>
+            <MenuItem value="walk-with">산책가요</MenuItem>
+            <MenuItem value="show-off">동물자랑</MenuItem>
+            <MenuItem value="sitter">시터공고</MenuItem>
+          </Select>
+          <Button variant="contained" sx={{ mt: 3, mb: 2, mx: 0.5, color: 'white' }} >
+
+            <Link to={`/board/create`}>글쓰기</Link>
+          </Button>
         </div>
-      ) : boardList.length > 0 ? (
-        <TableContainer component={Paper} >
-          <Table className="board-table" aria-label="게시판 테이블" >
-            <TableHead>
-              <TableRow>
-                <TableCell>글번호</TableCell>
-                <TableCell>제목</TableCell>
-                <TableCell>작성자</TableCell>
-                <TableCell>등록일</TableCell>
-                <TableCell>조회수</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {boardList.map((board) => (
-                <TableRow key={board.boardId}>
-                  <TableCell>{board.boardId}</TableCell>
-                  <TableCell component="th" scope="row" className="title">
-                    <Link to={`/board/${board.boardId}`}>{board.title}</Link>
-                  </TableCell>
-                  <TableCell>{board.writerNickname}</TableCell>
-                  <TableCell>{moment(board.moddate).format('YYYY-MM-DD HH:mm')}</TableCell>
-                  <TableCell>{board.clickCnt}</TableCell>
+        {boardList === null || status === 204 ? (
+          <div className="crying-image-container">
+            <img
+              src="https://bys-petgoorm.s3.ap-northeast-2.amazonaws.com/pet-profile/202309112022_nbiuirc51.jpeg"
+              alt="🥲"
+              className="crying-image"
+            />
+            <p className="text-overlay">게시물이 없어요!</p>
+          </div>
+        ) : boardList.length > 0 ? (
+          <TableContainer component={Paper} sx={{border: '1px solid #DCDCDC', borderRadius: 5}} >
+            <Table className="board-table" aria-label="게시판 테이블" >
+              <TableHead>
+                <TableRow>
+                  <TableCell>글번호</TableCell>
+                  <TableCell>제목</TableCell>
+                  <TableCell>작성자</TableCell>
+                  <TableCell>등록일</TableCell>
+                  <TableCell>조회수</TableCell>
                 </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-          <Paging totalPages={totalPages} currentPage={currentPage} onPageChange={handlePageChange} />
-          <SearchBar setSearch={setSearch} setKeyword={setKeyword} />
-        </TableContainer>
-      ) : (
-        <CircularProgress />
-      )}
+              </TableHead>
+              <TableBody>
+                {boardList.map((board) => (
+                  <TableRow key={board.boardId}>
+                    <TableCell>{board.boardId}</TableCell>
+                    <TableCell component="th" scope="row" className="title">
+                      <Link to={`/board/${board.boardId}`}>{board.title}</Link>
+                    </TableCell>
+                    <TableCell>{board.writerNickname}</TableCell>
+                    <TableCell>{moment(board.moddate).format('YYYY-MM-DD HH:mm')}</TableCell>
+                    <TableCell>{board.clickCnt}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+            <Paging totalPages={totalPages} currentPage={currentPage} onPageChange={handlePageChange} />
+            <SearchBar setSearch={setSearch} setKeyword={setKeyword} />
+          </TableContainer>
+        ) : (
+          <CircularProgress />
+        )}
+      </Container>
     </>
   );
 }

--- a/src/components/board/Reply.tsx
+++ b/src/components/board/Reply.tsx
@@ -1,0 +1,190 @@
+import api from "lib/api"
+import { Stack, Box, Button, TextField, Avatar, Divider, Typography, IconButton } from '@mui/material';
+import { useParams } from "react-router-dom";
+import React, { useEffect, useState } from 'react';
+import moment from 'moment';
+import CreateOutlinedIcon from '@mui/icons-material/CreateOutlined';
+import ClearOutlinedIcon from '@mui/icons-material/ClearOutlined';
+
+
+interface ReplyList {
+    rid: number,
+    content: string,
+    writerNickname: string,
+    moddate: string,
+    mine: boolean
+}
+
+export default function Reply(): JSX.Element {
+
+    const [refresh, setRefresh] = useState(1)
+
+
+    const { boardId } = useParams();
+
+    const [rId, setRId] = useState(0);
+
+    const [reply, setReply] = useState({
+        boardId: '',
+        content: ''
+    });
+
+    const [updateRepl, setUpdateRepl] = useState({
+        boardId: '',
+        content: ''
+    });
+
+
+    const [upButton, setUpButton] = useState(false);
+
+    const [replyList, setReplyList] = useState<ReplyList[] | null>();
+
+    //댓글 새로 등록
+    const handleReplyForm = (e) => {
+
+        //리랜더링 방지
+        e.preventDefault();
+        api.post("api/reply/create", JSON.stringify(reply))
+            .then((res) => {
+                console.log(res.data)
+                //refresh값으로 useeffect 관리(데이터 변화할때마다 state 상태 변화시킴(새로고침없이 데이터 랜더링))
+                setRefresh(refresh => refresh * -1);
+
+            }).catch((e) => {
+                console.log(e)
+            })
+    }
+
+
+    //댓글 수정
+    const handleUpdateRepl = () => {
+        api.put(`api/reply/update/${rId}`, JSON.stringify(updateRepl))
+            .then((res) => {
+                console.log(res.data)
+                window.location.reload();
+
+            }).catch((e) => {
+                console.log(e)
+            })
+    }
+
+    //댓글 삭제
+    const handleReplDelete = async (rid) => {
+        console.log("rid" + rid)
+        try {
+            const shouldDelete = window.confirm('댓글을 삭제하시겠습니까?');
+            if (shouldDelete) {
+                const res = await api.delete(`api/reply/delete/${rid}`);
+                console.log(res.data);
+                setRefresh(refresh => refresh * -1);
+            }
+        } catch (e) {
+            console.log(e);
+        }
+    }
+
+    //업데이트할 댓글과 댓글 등록용 input값 타겟 관리
+    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+        targetStateUpdater: React.Dispatch<React.SetStateAction<any>>) => {
+        const { value } = e.target;
+
+        targetStateUpdater((prevData) => ({
+            ...prevData,
+            content: value,
+            boardId: boardId
+        }))
+    }
+
+    //댓글 목록
+    const GetReplyList = () => {
+        api.get(`api/reply/list/${boardId}`)
+            .then((res) => {
+                setReplyList(res.data.data)
+                console.log(res.data.data)
+            }).catch((e) => {
+                console.log(e);
+            })
+
+    }
+
+    //업데이트 버튼 상태관리
+    const handleUpButton = () => {
+        setUpButton(true)
+    }
+
+
+    useEffect(() => {
+        GetReplyList();
+    }, [refresh])
+
+
+    return (
+        <>
+            <Box >
+                <Box component="form" sx={{ display: 'flex', justifyContent: 'center', m: 5 }}>
+                    <TextField
+                        onChange={(e) => handleInputChange(e, setReply)}
+                        value={reply.content}
+                        multiline
+                        maxRows={4}
+                        fullWidth
+                    />
+                    <Button type="submit" onClick={handleReplyForm} >등록</Button>
+                </Box>
+                <Divider sx={{ m: 5 }} />
+                {replyList && replyList.map(comment => (
+                    <Box key={comment.rid} sx={{ mx: 5 }}>
+                        <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={5}>
+                            {upButton && comment.mine ? (<>
+                                    <Typography noWrap variant="button" >{comment.writerNickname}</Typography>
+                                    <TextField
+                                    fullWidth
+                                        multiline
+                                        maxRows={4}
+                                        sx={{width:"40rem"}}
+                                        onChange={(e) => {
+                                            setRId(comment.rid);
+                                            console.log("rId" + comment.rid)
+                                            handleInputChange(e, setUpdateRepl)
+                                        }}
+
+                                        defaultValue={comment.content}
+                                    />
+                                <Stack direction="row" alignItems="center" >
+                                    <Button onClick={handleUpdateRepl}   >수정</Button>
+                                </Stack>
+                            </>) : <>
+                                <Stack direction="row" spacing={5}>
+                                    <Typography variant="button" >{comment.writerNickname}</Typography>
+                                    <Box >{comment.content}</Box></Stack>
+                                <Stack direction="row" alignItems="center">
+                                    {comment.mine ? (
+                                        <>
+                                            <Stack direction="row" >
+                                                <IconButton size="small" onClick={handleUpButton} >
+                                                    <CreateOutlinedIcon />
+                                                </IconButton>
+                                                <IconButton size="small"
+                                                    onClick={() => { handleReplDelete(comment.rid); }}>
+                                                    <ClearOutlinedIcon />
+                                                </IconButton>
+                                            </Stack>
+                                        </>
+                                    ) : <></>}
+                                    <Box sx={{ fontSize: "0.7rem", ml: 1, alignItems: "center" }}>{moment(comment.moddate).format('YYYY-MM-DD HH:mm')}</Box>
+                                </Stack>
+                            </>
+                            }
+
+
+                        </Stack>
+                        <Divider sx={{ my: 5 }} />
+
+                    </Box>
+                ))}
+            </Box>
+        </>
+    )
+}
+
+

--- a/src/components/board/SeachBar.tsx
+++ b/src/components/board/SeachBar.tsx
@@ -45,6 +45,7 @@ function SearchBar({ setKeyword, setSearch }: AreaProps) {
         component="form"
         sx={{
           "& .MuiTextField-root": { m: 1, width: "13rem" },
+          display:'flex', alignItems:'center', justifyContent:'center'
         }}
         noValidate
         autoComplete="off"

--- a/src/components/logo/Logo.js
+++ b/src/components/logo/Logo.js
@@ -3,8 +3,8 @@ import { forwardRef } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 // @mui
 import { useTheme } from '@mui/material/styles';
-import { Box, Link } from '@mui/material';
-
+import { Box, Link} from '@mui/material';
+import LogoImage from '../../styles/img/edit_logo2.png'
 // ----------------------------------------------------------------------
 
 const Logo = forwardRef(({ disabledLink = false, sx, ...other }, ref) => {
@@ -18,61 +18,29 @@ const Logo = forwardRef(({ disabledLink = false, sx, ...other }, ref) => {
 
   // OR using local (public folder)
   // -------------------------------------------------------
-  // const logo = (
-  //   <Box
-  //     component="img"
-  //     src="/logo/logo_single.svg" => your path
-  //     sx={{ width: 40, height: 40, cursor: 'pointer', ...sx }}
-  //   />
-  // );
 
   const logo = (
     <Box
-      ref={ref}
-      component="div"
-      sx={{
-        width: 40,
-        height: 40,
-        display: 'inline-flex',
-        ...sx,
-      }}
-      {...other}
-    >
-      <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 512 512">
-        <defs>
-          <linearGradient id="BG1" x1="100%" x2="50%" y1="9.946%" y2="50%">
-            <stop offset="0%" stopColor={PRIMARY_DARK} />
-            <stop offset="100%" stopColor={PRIMARY_MAIN} />
-          </linearGradient>
-
-          <linearGradient id="BG2" x1="50%" x2="50%" y1="0%" y2="100%">
-            <stop offset="0%" stopColor={PRIMARY_LIGHT} />
-            <stop offset="100%" stopColor={PRIMARY_MAIN} />
-          </linearGradient>
-
-          <linearGradient id="BG3" x1="50%" x2="50%" y1="0%" y2="100%">
-            <stop offset="0%" stopColor={PRIMARY_LIGHT} />
-            <stop offset="100%" stopColor={PRIMARY_MAIN} />
-          </linearGradient>
-        </defs>
-
-        <g fill={PRIMARY_MAIN} fillRule="evenodd" stroke="none" strokeWidth="1">
-          <path
-            fill="url(#BG1)"
-            d="M183.168 285.573l-2.918 5.298-2.973 5.363-2.846 5.095-2.274 4.043-2.186 3.857-2.506 4.383-1.6 2.774-2.294 3.939-1.099 1.869-1.416 2.388-1.025 1.713-1.317 2.18-.95 1.558-1.514 2.447-.866 1.38-.833 1.312-.802 1.246-.77 1.18-.739 1.111-.935 1.38-.664.956-.425.6-.41.572-.59.8-.376.497-.537.69-.171.214c-10.76 13.37-22.496 23.493-36.93 29.334-30.346 14.262-68.07 14.929-97.202-2.704l72.347-124.682 2.8-1.72c49.257-29.326 73.08 1.117 94.02 40.927z"
-          />
-          <path
-            fill="url(#BG2)"
-            d="M444.31 229.726c-46.27-80.956-94.1-157.228-149.043-45.344-7.516 14.384-12.995 42.337-25.267 42.337v-.142c-12.272 0-17.75-27.953-25.265-42.337C189.79 72.356 141.96 148.628 95.69 229.584c-3.483 6.106-6.828 11.932-9.69 16.996 106.038-67.127 97.11 135.667 184 137.278V384c86.891-1.611 77.962-204.405 184-137.28-2.86-5.062-6.206-10.888-9.69-16.994"
-          />
-          <path
-            fill="url(#BG3)"
-            d="M450 384c26.509 0 48-21.491 48-48s-21.491-48-48-48-48 21.491-48 48 21.491 48 48 48"
-          />
-        </g>
-      </svg>
-    </Box>
+      component="img"
+      src={LogoImage}
+      sx={{height: 40, cursor: 'pointer', ...sx }}
+    />
   );
+
+  // const logo = (
+  //   <Box
+  //     ref={ref}
+  //     component="div"
+  //     sx={{
+  //       width: 40,
+  //       height: 40,
+  //       display: 'inline-flex',
+  //       ...sx,
+  //     }}
+  //     {...other}
+  //   >
+  //   </Box>
+  // );
 
   if (disabledLink) {
     return <>{logo}</>;

--- a/src/components/member/Login.tsx
+++ b/src/components/member/Login.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import Cookies from 'js-cookie';
 import api from "lib/api";
-import Avatar from '@mui/material/Avatar';
 import Button from '@mui/material/Button';
 import TextField from '@mui/material/TextField';
 import FormControlLabel from '@mui/material/FormControlLabel';
@@ -10,8 +9,9 @@ import Link from '@mui/material/Link';
 import Paper from '@mui/material/Paper';
 import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
-import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import Typography from '@mui/material/Typography';
+import LogoImage from '../../styles/img/edit_logo2.png'
+import { Link as RouterLink } from 'react-router-dom';
 
 const Login = () => {
 
@@ -19,6 +19,7 @@ const Login = () => {
         email: '',
         password: ''
     });
+
 
     const onChangeHandler = (e) => {
         setInputValue((prevState) => {
@@ -35,7 +36,7 @@ const Login = () => {
             api.post("member/login", JSON.stringify(inputValue))
                 .then((res) => {
                     //console.log(res.data);
-                    Cookies.set ("key", res.data.data.accessToken);
+                    Cookies.set("key", res.data.data.accessToken);
                     alert('로그인 성공');
                     return window.location.replace('/');
                 })
@@ -73,9 +74,9 @@ const Login = () => {
                             alignItems: 'center',
                         }}
                     >
-                        <Avatar sx={{ m: 1, bgcolor: 'secondary.main' }}>
-                            <LockOutlinedIcon />
-                        </Avatar>
+                        <Link to="/" component={RouterLink} sx={{ display: 'contents' }}>
+                            <Box component="img" src={LogoImage} sx={{ height: 80, marginBottom: 3 }} />
+                        </Link>
                         <Typography component="h1" variant="h5">
                             로그인
                         </Typography>
@@ -89,7 +90,7 @@ const Login = () => {
                                 name="email"
                                 autoComplete="email"
                                 autoFocus
-                                value={inputValue.email} onChange={onChangeHandler} 
+                                value={inputValue.email} onChange={onChangeHandler}
                             />
 
                             <TextField
@@ -110,7 +111,7 @@ const Login = () => {
                             <Button
                                 fullWidth
                                 variant="contained"
-                                sx={{ mt: 3, mb: 2, color: 'white'}}
+                                sx={{ mt: 3, mb: 2, color: 'white' }}
                                 onClick={handleSubmit}
                             >
                                 Sign In
@@ -122,7 +123,7 @@ const Login = () => {
                                     </Link>
                                 </Grid>
                                 <Grid item>
-                                    <Link href="#" variant="body2">
+                                    <Link href="http://localhost:3000/signup" variant="body2">
                                         {"계정이 없으신가요? 회원가입"}
                                     </Link>
                                 </Grid>

--- a/src/components/member/Signup.tsx
+++ b/src/components/member/Signup.tsx
@@ -4,6 +4,13 @@ import { useNavigate } from "react-router-dom";
 import ReactDaumPost from 'react-daumpost-hook';
 import api from "lib/api";
 import useNicknameChecker from "lib/useNicknameChecker";
+import { Button, TextField, Container } from "@mui/material"
+import CssBaseline from '@mui/material/CssBaseline';
+import Grid from '@mui/material/Grid';
+import { Box, Link } from '@mui/material';
+import Typography from '@mui/material/Typography';
+import LogoImage from '../../styles/img/edit_logo2.png'
+import { Link as RouterLink } from 'react-router-dom';
 
 interface FormData {
   email: string;
@@ -13,10 +20,11 @@ interface FormData {
   nickname: string;
   address: string;
   phoneNumber: string;
+  bcode: string;
 }
 
 const Signup = () => {
-  const { register, handleSubmit, watch, formState: { errors } } = useForm<FormData>({ mode: 'all' });
+  const { register, handleSubmit, watch, formState: { errors }, setValue } = useForm<FormData>({ mode: 'all' });
   const [addressForm, setAddressForm] = useState('');
   const navigate = useNavigate();
   const password = useRef<string>();
@@ -28,12 +36,12 @@ const Signup = () => {
     isAvailedNickname: false
   });
 
-    //양방향 바운딩을 위해 usestate로 닉넴 중복체크(한글만 마지막 글자 잘리는 오류 발생)
-    const [inputNick, setInputNick] = useState('');
+  //양방향 바운딩을 위해 usestate로 닉넴 중복체크(한글만 마지막 글자 잘리는 오류 발생)
+  const [inputNick, setInputNick] = useState('');
 
-    const handleNickChange = (e) => {
-      setInputNick(e.target.value);
-    };
+  const handleNickChange = (e) => {
+    setInputNick(e.target.value);
+  };
 
 
   //닉네임 중복확인 커스텀 훅 사용
@@ -42,15 +50,20 @@ const Signup = () => {
 
   const handleFormSubmit = (data: FormData) => {
     if (checkTF.isAvailedEmail === true && checkNick === true) {
-        api.post("member/signup", JSON.stringify(data))
+      api.post("member/signup", JSON.stringify(data))
         .then((res) => {
           console.log(data);
           console.log(res.data);
+          alert('회원가입 성공')
+          navigate("/");
+
         })
         .catch((err) => {
           console.log(err);
+          console.log(data)
+          alert('회원가입 실패')
+
         });
-      navigate("/");
     } else {
       alert('아이디 또는 이메일 중복확인을 클릭해주세요.');
     }
@@ -58,21 +71,21 @@ const Signup = () => {
 
   const checkEmail = () => {
     const email = (document.getElementById("email") as HTMLInputElement)?.value;
-    console.log("email "+email)
+    console.log("email " + email)
     if (email && email.length > 0) {
       api.get(`member/checkEmail?email=${email}`)
-      .then((res) => {
-        if (res.data.statusCode === 200) {
-          alert('사용 가능한 이메일입니다.');
-          setCheckTF({ isAvailedNickname: checkTF.isAvailedNickname, isAvailedEmail: true });
-        } else {
-          alert('이미 존재하는 이메일입니다.');
-          setCheckTF({ isAvailedNickname: checkTF.isAvailedNickname, isAvailedEmail: false });
-        }
-      })
-      .catch((err) => {
-        console.log(err);
-      });
+        .then((res) => {
+          if (res.data.statusCode === 200) {
+            alert('사용 가능한 이메일입니다.');
+            setCheckTF({ isAvailedNickname: checkTF.isAvailedNickname, isAvailedEmail: true });
+          } else {
+            alert('이미 존재하는 이메일입니다.');
+            setCheckTF({ isAvailedNickname: checkTF.isAvailedNickname, isAvailedEmail: false });
+          }
+        })
+        .catch((err) => {
+          console.log(err);
+        });
     } else {
       alert('이메일을 입력해주세요.');
     }
@@ -81,8 +94,12 @@ const Signup = () => {
 
   const postConfig = {
     onComplete: (data) => {
-      setAddressForm(data.jibunAddress);
-      console.log(data.jibunAddress);
+      //address는 도로명(jibunAddresss는 없는 경우가 있어서 도로명으로 교체)
+      //지역별 글 조회는 법정동코드(bcode)로 합쉬당
+      setAddressForm(data.address);
+      setValue("bcode", data.bcode)
+      console.log("지번 " + data.jibunAddress);
+      console.log("법정동코드" + data.bcode);
     }
   };
   const postCode = ReactDaumPost(postConfig);
@@ -90,145 +107,226 @@ const Signup = () => {
   return (
     <>
       <div>
-        <form onSubmit={handleSubmit(handleFormSubmit)}>
-          <h1>회원 가입</h1>
-          이메일 :
-          <input
-            id="email"
-            type="text"
-            {...register("email", {
-              required: true,
-              pattern: {
-                value: /^([0-9a-zA-Z_.-]+)@([0-9a-zA-Z_-]+)(\.[0-9a-zA-Z_-]+){1,2}$/,
-                message: '올바르지 않은 이메일 형식입니다.'
-              },
-            })}
-          />
-          <button type="button" onClick={checkEmail} disabled={!!errors.email} >중복확인</button><br />
+        <Container component="main" maxWidth="sm" sx={{ padding: 3 }}>
+          <CssBaseline />
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              border: '1px solid #DCDCDC', borderRadius: 5,
+              padding: 4, backgroundColor: 'white'
+            }}
+          >
+            <Link to="/" component={RouterLink} sx={{ display: 'contents' }}>
+              <Box component="img" src={LogoImage} sx={{ height: 80, marginBottom: 3 }} />
+            </Link>
 
-          {errors.email && errors.email?.type === 'pattern' && (
-            <ErrorMessage error={errors.email} />
-          )}
+            <Typography component="h1" variant="h5">
+              회원가입
+            </Typography>
+            <Box component="form" noValidate onSubmit={handleSubmit(handleFormSubmit)} sx={{ mt: 3 }}>
 
-          이름 :
-          <input
-            type="text"
-            {...register("memberName", {
-              required: {
-                value: true,
-                message: '이름을 입력해주세요'
-              },
-              minLength: 2,
-              maxLength: 20
-            })}
-          /><br />
-          {errors.memberName && errors.memberName?.type === 'required' && (
-            <ErrorMessage error={errors.memberName} />
-          )}
-          
-          비밀번호 :
-          <input
-            type="password"
-            {...register("password", {
-              required: {
-                value: true,
-                message: '비밀번호를 입력해주세요'
-              },
-              pattern: {
-                value: /^(?=.*?[a-z])(?=.*?[0-9]).{8,}$/,
-                message: '비밀번호는 8자 이상이어야 하며, 숫자 및 영어 소문자를 모두 포함해야 합니다.'
-              }
-            })}
-          /><br />
-          {errors.password && errors.password?.type === 'pattern' && (
-            <ErrorMessage error={errors.password} />
-          )}
-          
-          비밀번호 확인 :
-          <input
-            type="password"
-            {...register("passwordCheck", {
-              required: true,
-              validate: value => value === password.current || "비밀번호가 일치하지 않습니다."
-            })}
-          /><br/>
-          {errors.passwordCheck && errors.passwordCheck?.type === 'validate' && (
-            <ErrorMessage error={errors.passwordCheck} />
-          )}
+              <Grid container spacing={2}>
+                <Grid item xs={12}>
+                  <Typography sx={{ color: '#969696' }}>이메일</Typography>
+                </Grid>
+                <Grid item xs={9}>
+                  <TextField
+                    size="small"
+                    hiddenLabel
+                    name="email"
+                    fullWidth
+                    id="email"
+                    {...register("email", {
+                      required: true,
+                      pattern: {
+                        value: /^([0-9a-zA-Z_.-]+)@([0-9a-zA-Z_-]+)(\.[0-9a-zA-Z_-]+){1,2}$/,
+                        message: '올바르지 않은 이메일 형식입니다.'
+                      },
+                    })}
+                    error={!!errors.email}
+                    helperText={errors.email?.message}
+                  />
+                </Grid>
+                <Grid item xs={3} sx={{ display: 'flex', alignItems: 'center' }}>
+                  <Button onClick={checkEmail} disabled={!!errors.email} variant="contained"
+                    sx={{ backgroundColor: '#FFAE8B', boxShadow: 'none', paddingY: 1 }} >중복확인</Button>
+                </Grid>
+                <Grid item xs={12}>
+                  <Typography sx={{ color: '#969696' }}>비밀번호</Typography>
+                </Grid>
+                <Grid item xs={12}>
+                  <TextField
+                    type="password"
+                    size="small"
+                    hiddenLabel
+                    fullWidth
+                    {...register("password", {
+                      required: {
+                        value: true,
+                        message: '비밀번호를 입력해주세요'
+                      },
+                      pattern: {
+                        value: /^(?=.*?[a-z])(?=.*?[0-9]).{8,}$/,
+                        message: '비밀번호는 8자 이상이어야 하며, 숫자 및 영어 소문자를 모두 포함해야 합니다.'
+                      }
+                    })}
+                    error={!!errors.password}
+                    helperText={errors.password?.message}
+                  />
+                </Grid>
 
-          닉네임 :
-          <input
-            id="nickname"
-            type="text"
-            {...register("nickname", {
-              required: {
-                value: true,
-                message: '닉네임을 입력해주세요'
-              },
-              pattern: {
-                value: /^(?=.*[a-z0-9가-힣])[a-z0-9가-힣]{2,16}$/,
-                message: '닉네임은 영문, 숫자 또는 한글로 2자 이상 16자 이하만 가능합니다.'
-              }
-            })}
-          onChange={handleNickChange}/>
-          <button type="button" onClick={checkNickname} disabled={!!errors.nickname}>중복확인</button><br />
-          {errors.nickname && errors.nickname?.type === 'pattern' && (
-            <ErrorMessage error={errors.nickname} />
-          )}
-          주소 :
-          <input
-            id="address"
-            type="text"
-            onClick={postCode}
-            value={addressForm}
-            {...register("address", {
-              required: {
-                value: true,
-                message: '주소를 입력해주세요'
-              }
-            })}
-          />
-          <button type="button" onClick={postCode} >주소 찾기</button><br />
-          {errors.address && errors.address?.type === 'required' && (
-            <ErrorMessage error={errors.address} />
-          )}
+                <Grid item xs={12}>
+                  <Typography sx={{ color: '#969696' }}>비밀번호 확인</Typography>
+                </Grid>
+                <Grid item xs={12}>
+                  <TextField
+                    type="password"
+                    size="small"
+                    hiddenLabel
+                    fullWidth
+                    {...register("passwordCheck", {
+                      required: true,
+                      validate: value => value === password.current || "비밀번호가 일치하지 않습니다."
+                    })}
+                    error={!!errors.passwordCheck}
+                    helperText={errors.passwordCheck?.message}
+                  />
+                </Grid>
 
-          핸드폰 번호 :
-          <input
-            type="text"
-            maxLength={11} 
-            {...register("phoneNumber", {
-              required: {
-                value: true,
-                message: '핸드폰 번호를 입력해주세요.'
-              },
-              pattern: {
-                value: /^01([0|1|6|7|8|9]?)-?([0-9]{3,4})-?([0-9]{4})$/,
-                message: '공백 없이 숫자만 입력해주세요.'
-              }
-            })}
-          /><br />
-          {errors.phoneNumber && (errors.phoneNumber?.type === 'required'|| 'pattern') && (
-            <ErrorMessage error={errors.phoneNumber} />
-          )}
+                <Grid item xs={8}>
+                  <Typography sx={{ color: '#969696' }}>닉네임</Typography>
+                </Grid>
+                <Grid item xs={4}>
+                  <Typography sx={{ color: '#969696' }}>이름</Typography>
+                </Grid>
+                <Grid item xs={5}>
+                  <TextField
+                    size="small"
+                    hiddenLabel
+                    name="email"
+                    fullWidth
+                    id="nickname"
+                    {...register("nickname", {
+                      required: {
+                        value: true,
+                        message: '닉네임을 입력해주세요'
+                      },
+                      pattern: {
+                        value: /^(?=.*[a-z0-9가-힣])[a-z0-9가-힣]{2,16}$/,
+                        message: '닉네임은 영문, 숫자 또는 한글로 2자 이상 16자 이하만 가능합니다.'
+                      }
+                    })}
+                    onChange={handleNickChange}
+                    error={!!errors.nickname}
+                    helperText={errors.nickname?.message}
+                  />
+                </Grid>
+                <Grid item xs={3} sx={{ display: 'flex', alignItems: 'center' }}>
+                  <Button onClick={checkNickname} disabled={!!errors.nickname} variant="contained"
+                    sx={{ backgroundColor: '#FFAE8B', boxShadow: 'none', paddingY: 1 }} >중복확인</Button>
+                </Grid>
 
-          <p><button type="submit">가입하기</button></p>
-        </form>
+                <Grid item xs={4}>
+                  <TextField
+                    size="small"
+                    hiddenLabel
+                    fullWidth
+                    {...register("memberName", {
+                      required: {
+                        value: true,
+                        message: '이름을 입력해주세요'
+                      },
+                      pattern: {
+                        value: /^(?=.*[a-z가-힣])[a-z가-힣]{2,16}$/,
+                        message: '이름은 영문 또는 한글로 2자 이상 16자 이하만 가능합니다.'
+
+                      }
+                    })}
+                    error={!!errors.memberName}
+                    helperText={errors.memberName?.message}
+                  />
+                </Grid>
+
+
+                <Grid item xs={12}>
+                  <Typography sx={{ color: '#969696' }}>핸드폰번호</Typography>
+                </Grid>
+                <Grid item xs={12}>
+                  <TextField
+                    size="small"
+                    hiddenLabel
+                    fullWidth
+                    inputProps={{ maxLength: 11, inputMode: 'numeric', pattern: '[0-9]*' }}
+                    type="text"
+
+                    {...register("phoneNumber", {
+                      required: {
+                        value: true,
+                        message: '핸드폰 번호를 입력해주세요.'
+                      },
+                      pattern: {
+                        value: /^01([0|1|6|7|8|9]?)-?([0-9]{3,4})-?([0-9]{4})$/,
+                        message: '공백 없이 숫자만 입력해주세요.'
+                      }
+                    })}
+                    error={!!errors.phoneNumber}
+                    helperText={errors.phoneNumber?.message}
+                  />
+                </Grid>
+                <Grid item xs={12}>
+                  <Typography sx={{ color: '#969696' }}>주소</Typography>
+                </Grid>
+                <Grid item xs={12}>
+                  <TextField
+                    size="small"
+                    hiddenLabel
+                    fullWidth
+                    type="text"
+                    id="address"
+                    onClick={postCode}
+                    value={addressForm}
+                    {...register("address", {
+                      required: {
+                        value: true,
+                        message: '주소를 입력해주세요'
+                      }
+                    })}
+                    error={!!errors.address}
+                    helperText={errors.address?.message}
+                  />
+
+                </Grid>
+                <input
+                  type="hidden"
+                  {...register("bcode", {
+                    required: true
+                  })}
+                />
+                {errors.bcode && <span></span>}
+              </Grid>
+              <Button
+                type="submit"
+                fullWidth
+                variant="contained"
+                sx={{ backgroundColor: '#FFAE8B', boxShadow: 'none', paddingY: 1, marginY: 3 }}
+              >
+                가입하기
+              </Button>
+              <Grid container justifyContent="flex-end">
+                <Grid item>
+                  <Link href="http://localhost:3000/login" variant="body2">
+                    이미 계정이 존재하시나요? 로그인
+                  </Link>
+                </Grid>
+              </Grid>
+            </Box>
+          </Box>
+        </Container>
       </div>
     </>
   );
 };
 
 export default Signup;
-
-
-export const ErrorMessage = ({ error }) => (
-    error && (
-      <div>
-        <span>
-          {error.message}
-        </span>
-      </div>
-    )
-  );
-  

--- a/src/components/member/mypage/EditNick.tsx
+++ b/src/components/member/mypage/EditNick.tsx
@@ -1,10 +1,9 @@
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
-import ReactDaumPost from 'react-daumpost-hook';
 import api from "lib/api";
-import { ErrorMessage } from "../Signup";
 import useNicknameChecker from "lib/useNicknameChecker";
+import { Container, Typography, Grid, TextField, Box, Link, Button, Paper, Card } from '@mui/material';
 
 interface FormData {
   nickname: string;
@@ -25,62 +24,108 @@ const EditNick = () => {
   const { checkNickname, checkNick } = useNicknameChecker(inputNick);
 
   const handleFormSubmit = (data: FormData) => {
-    if(checkNick){
-        api.patch("member/editnick", JSON.stringify(data))
+    if (checkNick) {
+      api.patch("member/editnick", JSON.stringify(data))
         .then((res) => {
           console.log(data);
           console.log(res.data);
-          if(res.data.statusCode == 200){
-          alert(res.data.message)
-          navigate("/");
+          if (res.data.statusCode == 200) {
+            alert(res.data.message)
+            navigate("/");
           }
         })
         .catch((err) => {
           console.log(err);
         });
     }
-    else{
-        alert("닉네임 중복확인을 클릭해주세요.")
+    else {
+      alert("닉네임 중복확인을 클릭해주세요.")
     }
   };
 
-  
+
 
   return (
+
     <>
-      <div>
-        <form onSubmit={handleSubmit(handleFormSubmit)}>
-          <h1>닉네임 변경</h1>
+      <Container component="main" maxWidth="sm" sx={{ padding: 3 }}>
 
-          닉네임 :
-          <input 
-            id="nickname"
-            type="text"
-            {...register("nickname", {
-              required: {
-                value: true,
-                message: '닉네임을 입력해주세요'
-              },
-              pattern: {
-                value: /^(?=.*[a-z0-9가-힣])[a-z0-9가-힣]{2,16}$/,
-                message: '닉네임은 영문, 숫자 또는 한글로 2자 이상 16자 이하만 가능합니다.'
-              }
-            })}
-            onChange={handleChange}
+        <Card
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            border: '1px solid #DCDCDC', borderRadius: 5,
+            padding: 4, backgroundColor: 'white'
+          }}
+        >
+          <Typography variant="h4" sx={{ mb: 5 }}>
+            닉네임 변경
+          </Typography>
+          <Box component="form" noValidate onSubmit={handleSubmit(handleFormSubmit)} sx={{ mt: 3 }}>
 
-         />
-          <button type="button" onClick={checkNickname} disabled={!!errors.nickname}>중복확인</button><br />
-          {errors.nickname && errors.nickname?.type === 'pattern' && (
-            <ErrorMessage error={errors.nickname} />
-          )}
+            <Grid container spacing={2}>
 
-          <p><button type="submit">변경하기</button></p>
-        </form>
-      </div>
+              <Grid item xs={12}>
+                <Typography sx={{ color: '#969696' }}>현재 닉네임</Typography>
+              </Grid>
+              <Grid item xs={12}>
+                <TextField
+                  type="text"
+                  size="small"
+                  hiddenLabel
+                  fullWidth
+                  inputProps={
+                    { readOnly: true, }
+                  }
+                  value="닉네임 들어올 곳"
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <Typography sx={{ color: '#969696' }}>새 닉네임</Typography>
+              </Grid>
+              <Grid item xs={8}>
+                <TextField
+                  type="text"
+                  size="small"
+                  id="nickname"
+                  hiddenLabel
+                  fullWidth
+                  {...register("nickname", {
+                    required: {
+                      value: true,
+                      message: '닉네임을 입력해주세요'
+                    },
+                    pattern: {
+                      value: /^(?=.*[a-z0-9가-힣])[a-z0-9가-힣]{2,16}$/,
+                      message: '닉네임은 영문, 숫자 또는 한글로 2자 이상 16자 이하만 가능합니다.'
+                    }
+                  })}
+                  onChange={handleChange}
+                  error={!!errors.nickname}
+                  helperText={errors.nickname?.message}
+                />
+              </Grid>
+              <Grid item xs={4} sx={{ display: 'flex', justifyContent: 'center' }}>
+                <Button onClick={checkNickname} disabled={!!errors.nickname} variant="contained"
+                  sx={{ backgroundColor: '#FFAE8B', boxShadow: 'none', paddingY: 1 }} >중복확인</Button>
+              </Grid>
+
+            </Grid>
+            <Button
+              type="submit"
+              fullWidth
+              variant="contained"
+              sx={{ backgroundColor: '#FFAE8B', boxShadow: 'none', paddingY: 1, marginY: 3 }}
+            >
+              변경하기
+            </Button>
+          </Box>
+        </Card>
+      </Container>
     </>
   );
 };
 
 export default EditNick;
 
-  

--- a/src/components/member/mypage/EditPw.tsx
+++ b/src/components/member/mypage/EditPw.tsx
@@ -1,10 +1,9 @@
-import { useRef, useState } from "react";
+import { useRef } from "react";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
-import ReactDaumPost from 'react-daumpost-hook';
 import api from "lib/api";
-import { ErrorMessage } from "../Signup";
-
+import { Container, Typography, Grid, TextField, Box, Link, Button, Card } from '@mui/material';
+// components
 interface FormData {
 
   updatePW: string;
@@ -20,84 +19,118 @@ const EditPw = () => {
   updatePW.current = watch("updatePW");
 
   const handleFormSubmit = (data: FormData) => {
-        api.patch("member/editpw", JSON.stringify(data))
-        .then((res) => {
-          console.log(data);
-          console.log(res.data);
-          if(res.data.statusCode == 200){
+    api.patch("member/editpw", JSON.stringify(data))
+      .then((res) => {
+        console.log(data);
+        console.log(res.data);
+        if (res.data.statusCode == 200) {
           alert(res.data.message)
           navigate("/");
-          }
-        })
-        .catch((err) => {
-          console.log(err);
-        });
-    
+        }
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+
   };
 
   return (
     <>
-      <div>
-        <form onSubmit={handleSubmit(handleFormSubmit)}>
-          <h1>비밀번호 변경</h1>
+      <Container component="main" maxWidth="sm" sx={{ padding: 3 }}>
+        <Card
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            border: '1px solid #DCDCDC', borderRadius: 5,
+            padding: 4, backgroundColor: 'white'
+          }}
+        >
+          <Typography variant="h4" sx={{ mb: 5 }}>
+            비밀번호 변경
+          </Typography>
+          <Box component="form" noValidate onSubmit={handleSubmit(handleFormSubmit)} sx={{ mt: 3 }}>
 
-          현재 비밀번호 :
-          <input
-            type="password"
-            {...register("nowPW", {
-              required: {
-                value: true,
-                message: '비밀번호를 입력해주세요'
-              },
-              pattern: {
-                value: /^(?=.*?[a-z])(?=.*?[0-9]).{8,}$/,
-                message: '비밀번호는 8자 이상이어야 하며, 숫자 및 영어 소문자를 모두 포함해야 합니다.'
-              }
-            })}
-          /><br />
-          {errors.nowPW && errors.nowPW?.type === 'pattern' && (
-            <ErrorMessage error={errors.nowPW} />
-          )}
-          
-          바꿀 비밀번호 :
-          <input
-            type="password"
-            {...register("updatePW", {
-              required: {
-                value: true,
-                message: '비밀번호를 입력해주세요'
-              },
-              pattern: {
-                value: /^(?=.*?[a-z])(?=.*?[0-9]).{8,}$/,
-                message: '비밀번호는 8자 이상이어야 하며, 숫자 및 영어 소문자를 모두 포함해야 합니다.'
-              }
-            })}
-          /><br />
-          {errors.updatePW && errors.updatePW?.type === 'pattern' && (
-            <ErrorMessage error={errors.updatePW} />
-          )}
-          
-          비밀번호 확인 :
-          <input
-            type="password"
-            {...register("passwordCheck", {
-              required: true,
-              validate: value => value === updatePW.current || "비밀번호가 일치하지 않습니다."
-            })}
-          /><br/>
-          {errors.passwordCheck && errors.passwordCheck?.type === 'validate' && (
-            <ErrorMessage error={errors.passwordCheck} />
-          )}
+            <Grid container spacing={2}>
+              <Grid item xs={12}>
+                <Typography sx={{ color: '#969696' }}>현재 비밀번호</Typography>
+              </Grid>
+              <Grid item xs={12}>
+                <TextField
+                  type="password"
+                  size="small"
+                  hiddenLabel
+                  fullWidth
+                  {...register("nowPW", {
+                    required: {
+                      value: true,
+                      message: '비밀번호를 입력해주세요'
+                    },
+                    pattern: {
+                      value: /^(?=.*?[a-z])(?=.*?[0-9]).{8,}$/,
+                      message: '비밀번호는 8자 이상이어야 하며, 숫자 및 영어 소문자를 모두 포함해야 합니다.'
+                    }
+                  })}
+                  error={!!errors.nowPW}
+                  helperText={errors.nowPW?.message}
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <Typography sx={{ color: '#969696' }}>새 비밀번호</Typography>
+              </Grid>
+              <Grid item xs={12}>
+                <TextField
+                  type="password"
+                  size="small"
+                  hiddenLabel
+                  fullWidth
+                  {...register("updatePW", {
+                    required: {
+                      value: true,
+                      message: '비밀번호를 입력해주세요'
+                    },
+                    pattern: {
+                      value: /^(?=.*?[a-z])(?=.*?[0-9]).{8,}$/,
+                      message: '비밀번호는 8자 이상이어야 하며, 숫자 및 영어 소문자를 모두 포함해야 합니다.'
+                    }
+                  })}
+                  error={!!errors.updatePW}
+                  helperText={errors.updatePW?.message}
+                />
+              </Grid>
 
-
-
-          <p><button type="submit">변경하기</button></p>
-        </form>
-      </div>
+              <Grid item xs={12}>
+                <Typography sx={{ color: '#969696' }}>새 비밀번호 확인</Typography>
+              </Grid>
+              <Grid item xs={12}>
+                <TextField
+                  type="password"
+                  size="small"
+                  hiddenLabel
+                  fullWidth
+                  {...register("passwordCheck", {
+                    required: true,
+                    validate: value => value === updatePW.current || "비밀번호가 일치하지 않습니다."
+                  })}
+                  error={!!errors.passwordCheck}
+                  helperText={errors.passwordCheck?.message}
+                />
+              </Grid>
+            </Grid>
+            <Button
+              type="submit"
+              fullWidth
+              variant="contained"
+              sx={{ backgroundColor: '#FFAE8B', boxShadow: 'none', paddingY: 1, marginY: 3 }}
+            >
+              변경하기
+            </Button>
+          </Box>
+        </Card>
+      </Container>
     </>
   );
 };
 
 export default EditPw;
 
-  

--- a/src/components/pet/PetEdit.tsx
+++ b/src/components/pet/PetEdit.tsx
@@ -1,11 +1,9 @@
-import React, { useRef, useState, useEffect } from "react";
-import axios from "axios";
+import { useState, useEffect } from "react";
 import { useForm } from "react-hook-form";
-import { useNavigate } from "react-router-dom";
-import { ErrorMessage } from "components/member/Signup";
 import api from "lib/api";
 import PetImgUpload from "./PetImgUpload";
 import { uploadS3 } from "lib/s3";
+import { Container, Typography, Grid, TextField, Box, Link, Button, Card } from '@mui/material';
 
 interface PetFormData {
     petname: string;
@@ -38,13 +36,6 @@ export const PetEdit = () => {
     const [fileName, setFileName] = useState<string | null>(null);
     const [fileType, setFileType] = useState<string | null>(null);
 
-    const navigate = useNavigate();
-
-    //input 창 숫자만 입력가능하도록
-    const numberInput = (e: React.FormEvent<HTMLInputElement>) => {
-        e.currentTarget.value = e.currentTarget.value.replace(/[^0-9.]/g, '').replace(/(\..*)\./g, '$1');
-    }
-
     const handleFormSubmit = async (data: PetFormData) => {
         const formData = new FormData();
         const extension = fileName.split(".").pop(); // 파일 확장자 추출
@@ -67,7 +58,7 @@ export const PetEdit = () => {
         api.put(`pet/edit/${petData.petId}`, JSON.stringify(data))
             .then((res) => {
                 alert("업로드 완료!");
-                navigate("/");
+                window.location.replace("/");
                 console.log(res.data);
 
             }).catch((err) => {
@@ -101,86 +92,149 @@ export const PetEdit = () => {
     return (
         <>
         {petData ?
-            <div className="petform">
-                <form onSubmit={handleSubmit(handleFormSubmit)} className="PetForm">
-                    <h1>펫 수정</h1><br />
-                    <PetImgUpload setImageFile={setImageFile} setFilename={setFileName} setFileType={setFileType} nowProfile={petData.petUrl}/>
-                    펫 이름 :
-                    <input type="text" defaultValue ={petData.petname}
-                        {...register("petname", {
-                            required: {
-                                value: true,
-                                message: '반려 동물의 이름을 입력해주세요'
-                            },
-                            minLength: 2,
-                            maxLength: 20
-                        })}
-                    /><br />
-                    {errors.petname && errors.petname?.type === 'required' && (
-                        <ErrorMessage error={errors.petname} />
+            <>
+            <Container component="main" maxWidth="sm" sx={{ padding: 3 }}>
+                <Card
+                    sx={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        border: '1px solid #DCDCDC', borderRadius: 5,
+                        padding: 4, backgroundColor: 'white'
+                    }}
+                >
+                    <Typography variant="h4" sx={{ mb: 2 }}>
+                        펫 수정
+                    </Typography>
 
-                    )}
+                    <Box component="form" noValidate onSubmit={handleSubmit(handleFormSubmit)} sx={{ mt: 3 }}>
 
-                    나이 :
-                    <input type="text" onInput={numberInput} defaultValue={petData.age}
-                        {...register("age", {
-                            required: {
-                                value: true,
-                                message: '반려 동물의 나이를 입력해주세요.(숫자만 입력가능)'
-                            }
-                        })}
-                    /><br />
-                    {errors.age && errors.age?.type === 'required' && (
-                        <ErrorMessage error={errors.age} />
+                        <Grid container spacing={2}>
+                            <Grid item xs={12}>
+                                <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+                                    <PetImgUpload setImageFile={setImageFile} setFilename={setFileName} setFileType={setFileType} nowProfile={null} />
+                                </Box>
+                            </Grid>
+                            <Grid item xs={2} sx={{ display: 'flex', alignItems: 'center' }}>
+                                <Typography sx={{ color: '#969696' }}>이름</Typography>
+                            </Grid>
+                            <Grid item xs={10}>
+                                <TextField type="text"
+                                    size="small"
+                                    hiddenLabel
+                                    fullWidth
+                                    defaultValue ={petData.petname}
+                                    {...register("petname", {
+                                        required: {
+                                            value: true,
+                                            message: '반려 동물의 이름을 입력해주세요'
+                                        },
+                                        minLength: 2,
+                                        maxLength: 20
+                                    })}
+                                    error={!!errors.petname}
+                                    helperText={errors.petname?.message}
+                                />
 
-                    )}
+                            </Grid>
+                            <Grid item xs={2} sx={{ display: 'flex', alignItems: 'center' }}>
+                                <Typography sx={{ color: '#969696' }}>나이</Typography>
+                            </Grid>
+                            <Grid item xs={10}>
+                                <TextField
+                                    size="small"
+                                    hiddenLabel
+                                    fullWidth
+                                    type="number"
+                                    defaultValue ={petData.age}
+                                    {...register("age", {
+                                        required: {
+                                            value: true,
+                                            message: '반려 동물의 나이를 입력해주세요.(숫자만 입력가능)'
+                                        },
+                                    })}
+                                    error={!!errors.age}
+                                    helperText={errors.age?.message}
+                                />
+                            </Grid>
 
-                    펫 종류 :
-                    <input type="text" defaultValue={petData.type}
-                        {...register("type", {
-                            required: {
-                                value: true,
-                                message: '반려 동물의 종을 입력해주세요'
-                            },
-                            minLength: 2,
-                            maxLength: 20
-                        })}
-                    /><br />
-                    {errors.type && errors.type?.type === 'required' && (
-                        <ErrorMessage error={errors.type} />
-                    )}
+                            <Grid item xs={2} sx={{ display: 'flex', alignItems: 'center' }}>
+                                <Typography sx={{ color: '#969696' }}>종류</Typography>
+                            </Grid>
+                            <Grid item xs={10}>
+                                <TextField
+                                    size="small"
+                                    hiddenLabel
+                                    fullWidth
+                                    type="text"
+                                    defaultValue ={petData.type}
+                                    {...register("type", {
+                                        required: {
+                                            value: true,
+                                            message: '반려 동물의 종을 입력해주세요'
+                                        },
+                                        minLength: 2,
+                                        maxLength: 20
+                                    })}
+                                    error={!!errors.type}
+                                    helperText={errors.type?.message}
+                                /></Grid>
 
-                    몸무게 :
-                    <input type="text" onInput={numberInput} defaultValue={petData.weight}
-                        {...register("weight", {
-                            required: {
-                                value: true,
-                                message: '반려 동물의 몸무게를 입력해주세요.(숫자만 입력가능)'
-                            }
-                        })}
-                    /><br />
-                    {errors.weight && errors.weight?.type === 'required' && (
-                        <ErrorMessage error={errors.weight} />
+                            <Grid item xs={2} sx={{ display: 'flex', alignItems: 'center' }}>
+                                <Typography sx={{ color: '#969696' }}>몸무게</Typography>
+                            </Grid>
+                            <Grid item xs={10}>
+                                <TextField
+                                    size="small"
+                                    hiddenLabel
+                                    fullWidth
+                                    type="number"
+                                    defaultValue ={petData.weight}
+                                    {...register("weight", {
+                                        required: {
+                                            value: true,
+                                            message: '반려 동물의 몸무게를 입력해주세요.(숫자만 입력가능)'
+                                        },
+                                    })}
+                                    error={!!errors.weight}
+                                    helperText={errors.weight?.message}
+                                />
+                            </Grid>
 
-                    )}
+                            <Grid item xs={3} sx={{ display: 'flex', alignItems: 'center' }}>
+                                <Typography sx={{ color: '#969696' }}>처음 만난 날</Typography>
+                            </Grid>
+                            <Grid item xs={9}>
+                                <TextField
+                                    size="small"
+                                    hiddenLabel
+                                    fullWidth
+                                    type="date"
+                                    defaultValue={formattedDate} 
+                                    {...register("firstmet", {
+                                        required: {
+                                            value: true,
+                                            message: '반려 동물과의 처음 만난 날을 입력해주세요'
+                                        }
+                                    })}
+                                    error={!!errors.firstmet}
+                                    helperText={errors.firstmet?.message}
 
-                    처음 만난 날:<input type="date" id="firstmet" defaultValue={formattedDate} 
-                        {...register("firstmet", {
-                            required: {
-                                value: true,
-                                message: '반려 동물과의 처음 만난 날을 입력해주세요'
-                            }
-                        })} /><br />
-                    {errors.firstmet && errors.firstmet?.type === 'required' && (
-                        <ErrorMessage error={errors.firstmet} />
+                                /></Grid>
 
-                    )}<br />
-                    <p>
-                        <button type="submit" >펫 수정</button>
-                    </p><br />
-
-                </form>
-            </div>
+                        </Grid>
+                        <Button
+                            type="submit"
+                            fullWidth
+                            variant="contained"
+                            sx={{ backgroundColor: '#FFAE8B', boxShadow: 'none', paddingY: 1, marginY: 3 }}
+                        >
+                            수정하기
+                        </Button>
+                    </Box>
+                </Card>
+            </Container>
+            </>
 : <></>}
         </>
     )

--- a/src/components/pet/PetForm.tsx
+++ b/src/components/pet/PetForm.tsx
@@ -1,12 +1,10 @@
-import React, { useRef, useState, useEffect } from "react";
-import axios from "axios";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
-import { useNavigate } from "react-router-dom";
-import { ErrorMessage } from "components/member/Signup";
-import Cookies from 'js-cookie';
+
 import api from "lib/api";
 import PetImgUpload from "./PetImgUpload";
 import { uploadS3 } from "lib/s3";
+import { Container, Typography, Grid, TextField, Box, Link, Button, Card } from '@mui/material';
 
 interface PetFormData {
     petname: string;
@@ -33,13 +31,6 @@ export const PetForm = () => {
     const [fileName, setFileName] = useState<string | null>(null);
     const [fileType, setFileType] = useState<string | null>(null);
 
-    const navigate = useNavigate();
-    const accessToken = Cookies.get('key');
-
-    //input 창 숫자만 입력가능하도록
-    const numberInput = (e: React.FormEvent<HTMLInputElement>) => {
-        e.currentTarget.value = e.currentTarget.value.replace(/[^0-9.]/g, '').replace(/(\..*)\./g, '$1');
-    }
 
     const handleFormSubmit = async (data: PetFormData) => {
         const formData = new FormData();
@@ -53,11 +44,11 @@ export const PetForm = () => {
         formData.append('name', fileName2);
         formData.append('type', fileType);
 
-        console.log("formData "+ formData.get('file'));
+        console.log("formData " + formData.get('file'));
 
         //s3에 파일 업로드 및 링크 반환
         const petUrl = await uploadS3(formData)
-        console.log("peturl "+petUrl)
+        console.log("peturl " + petUrl)
         data.petUrl = petUrl;
 
         api.post("pet/petform", JSON.stringify(data))
@@ -80,91 +71,148 @@ export const PetForm = () => {
 
     return (
         <>
-            <div className="petform">
-                <form onSubmit={handleSubmit(handleFormSubmit)} className="PetForm">
-                    <h1>펫 등록</h1><br />
-                    <PetImgUpload setImageFile={setImageFile} setFilename={setFileName} setFileType={setFileType} nowProfile={null}/>
+            <Container component="main" maxWidth="sm" sx={{ padding: 3 }}>
+                <Card
+                    sx={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        border: '1px solid #DCDCDC', borderRadius: 5,
+                        padding: 4, backgroundColor: 'white'
+                    }}
+                >
+                    <Typography variant="h4" sx={{ mb: 2 }}>
+                        펫 등록
+                    </Typography>
 
-                    펫 이름 :
-                    <input type="text"
-                        {...register("petname", {
-                            required: {
-                                value: true,
-                                message: '반려 동물의 이름을 입력해주세요'
-                            },
-                            minLength: 2,
-                            maxLength: 20
-                        })}
-                    /><br />
-                    {errors.petname && errors.petname?.type === 'required' && (
-                        <ErrorMessage error={errors.petname} />
+                    <Box component="form" noValidate onSubmit={handleSubmit(handleFormSubmit)} sx={{ mt: 3 }}>
 
-                    )}
+                        <Grid container spacing={2}>
+                            <Grid item xs={12}>
+                                <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+                                    <PetImgUpload setImageFile={setImageFile} setFilename={setFileName} setFileType={setFileType} nowProfile={null} />
+                                </Box>
+                            </Grid>
+                            <Grid item xs={2} sx={{ display: 'flex', alignItems: 'center' }}>
+                                <Typography sx={{ color: '#969696' }}>이름</Typography>
+                            </Grid>
+                            <Grid item xs={10}>
+                                <TextField type="text"
+                                    size="small"
+                                    hiddenLabel
+                                    fullWidth
+                                    {...register("petname", {
+                                        required: {
+                                            value: true,
+                                            message: '반려 동물의 이름을 입력해주세요'
+                                        },
+                                        minLength: 2,
+                                        maxLength: 20
+                                    })}
+                                    error={!!errors.petname}
+                                    helperText={errors.petname?.message}
+                                />
 
-                    나이 :
-                    <input type="text" onInput={numberInput}
-                        {...register("age", {
-                            required: {
-                                value: true,
-                                message: '반려 동물의 나이를 입력해주세요.(숫자만 입력가능)'
-                            }
-                        })}
-                    /><br />
-                    {errors.age && errors.age?.type === 'required' && (
-                        <ErrorMessage error={errors.age} />
+                            </Grid>
+                            <Grid item xs={2} sx={{ display: 'flex', alignItems: 'center' }}>
+                                <Typography sx={{ color: '#969696' }}>나이</Typography>
+                            </Grid>
+                            <Grid item xs={10}>
+                                <TextField
+                                    size="small"
+                                    hiddenLabel
+                                    fullWidth
+                                    type="number"
 
-                    )}
+                                    {...register("age", {
+                                        required: {
+                                            value: true,
+                                            message: '반려 동물의 나이를 입력해주세요.(숫자만 입력가능)'
+                                        },
+                                    })}
+                                    error={!!errors.age}
+                                    helperText={errors.age?.message}
+                                />
+                            </Grid>
 
-                    펫 종류 :
-                    <input type="text"
-                        {...register("type", {
-                            required: {
-                                value: true,
-                                message: '반려 동물의 종을 입력해주세요'
-                            },
-                            minLength: 2,
-                            maxLength: 20
-                        })}
-                    /><br />
-                    {errors.type && errors.type?.type === 'required' && (
-                        <ErrorMessage error={errors.type} />
-                    )}
+                            <Grid item xs={2} sx={{ display: 'flex', alignItems: 'center' }}>
+                                <Typography sx={{ color: '#969696' }}>종류</Typography>
+                            </Grid>
+                            <Grid item xs={10}>
+                                <TextField
+                                    size="small"
+                                    hiddenLabel
+                                    fullWidth
+                                    type="text"
+                                    {...register("type", {
+                                        required: {
+                                            value: true,
+                                            message: '반려 동물의 종을 입력해주세요'
+                                        },
+                                        minLength: 2,
+                                        maxLength: 20
+                                    })}
+                                    error={!!errors.type}
+                                    helperText={errors.type?.message}
+                                /></Grid>
 
-                    몸무게 :
-                    <input type="text" onInput={numberInput}
-                        {...register("weight", {
-                            required: {
-                                value: true,
-                                message: '반려 동물의 몸무게를 입력해주세요.(숫자만 입력가능)'
-                            }
-                        })}
-                    /><br />
-                    {errors.weight && errors.weight?.type === 'required' && (
-                        <ErrorMessage error={errors.weight} />
+                            <Grid item xs={2} sx={{ display: 'flex', alignItems: 'center' }}>
+                                <Typography sx={{ color: '#969696' }}>몸무게</Typography>
+                            </Grid>
+                            <Grid item xs={10}>
+                                <TextField
+                                    size="small"
+                                    hiddenLabel
+                                    fullWidth
+                                    type="number"
 
-                    )}
+                                    {...register("weight", {
+                                        required: {
+                                            value: true,
+                                            message: '반려 동물의 몸무게를 입력해주세요.(숫자만 입력가능)'
+                                        },
+                                    })}
+                                    error={!!errors.weight}
+                                    helperText={errors.weight?.message}
+                                />
+                            </Grid>
 
-                    처음 만난 날:<input type="date"
-                        {...register("firstmet", {
-                            required: {
-                                value: true,
-                                message: '반려 동물과의 처음 만난 날을 입력해주세요'
-                            }
-                        })} /><br />
-                    {errors.firstmet && errors.firstmet?.type === 'required' && (
-                        <ErrorMessage error={errors.firstmet} />
+                            <Grid item xs={3} sx={{ display: 'flex', alignItems: 'center' }}>
+                                <Typography sx={{ color: '#969696' }}>처음 만난 날</Typography>
+                            </Grid>
+                            <Grid item xs={9}>
+                                <TextField
+                                    size="small"
+                                    hiddenLabel
+                                    fullWidth
+                                    type="date"
+                                    {...register("firstmet", {
+                                        required: {
+                                            value: true,
+                                            message: '반려 동물과의 처음 만난 날을 입력해주세요'
+                                        }
+                                    })}
+                                    error={!!errors.firstmet}
+                                    helperText={errors.firstmet?.message}
 
-                    )}<br />
-                    <p>
-                        <button type="submit" >펫 등록</button>
-                    </p><br />
+                                /></Grid>
 
-                </form>
-            </div>
+                        </Grid>
+                        <Button
+                            type="submit"
+                            fullWidth
+                            variant="contained"
+                            sx={{ backgroundColor: '#FFAE8B', boxShadow: 'none', paddingY: 1, marginY: 3 }}
+                        >
+                            등록하기
+                        </Button>
+                    </Box>
+                </Card>
+            </Container>
         </>
     )
 
 
 }
 
-;
+    ;

--- a/src/components/pet/PetImgUpload.tsx
+++ b/src/components/pet/PetImgUpload.tsx
@@ -1,14 +1,20 @@
-import React, { useRef, useState, useEffect } from "react";
-import { useForm } from "react-hook-form";
+import React, { useState } from "react";
 import styled from 'styled-components';
+import { Avatar } from '@mui/material';
+import { IconButton } from '@mui/material';
+
+const Input = styled('input')({
+    display: 'none',
+});
+
 
 interface PetImgUploadProps {
     setImageFile: (file: File | null) => void;
     setFilename: (filename: string | null) => void;
     setFileType: (filename: string | null) => void;
     nowProfile: string | null
-  }
-  
+}
+
 
 export default function PetImgUpload({ setImageFile, setFilename, setFileType, nowProfile }: PetImgUploadProps) {
 
@@ -23,30 +29,25 @@ export default function PetImgUpload({ setImageFile, setFilename, setFileType, n
         setFileType(file.type)
         setImagePreview(URL.createObjectURL(file));
         // 파일 업로드 로직
-      };
+    };
 
     return (
         <div>
-            <label>프로필 이미지 추가</label>
-            <input type="file" id="profileImg" 
-                accept=".jpg, .png, .jpeg, .JPG, .PNG, .JPEG" onChange={onUpload}/>
-            {nowProfile ||imagePreview ? <ThumbnailContainer><PreviewPet src={imagePreview? imagePreview: nowProfile} /></ThumbnailContainer> : <div />}
             
+            <label htmlFor="icon-button-file">
+                <Input accept=".jpg, .png, .jpeg, .JPG, .PNG, .JPEG" id="icon-button-file" type="file" onChange={onUpload} />
+                <IconButton
+                    color="primary"
+                    aria-label="upload picture"
+                    component="span"
+                >
+                    <Avatar sx={{ width: 200, height: 200 }} src={imagePreview} />
+                </IconButton>
+            </label>
+
         </div>
     )
 
 }
 
-const PreviewPet = styled.img`
-    max-width: 100%;
-    max-height: 100%;
-`
-const ThumbnailContainer = styled.div`
-    width: 200px;
-    height: 200px;
-    border: 1px solid #ccc;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-`;
 

--- a/src/layouts/dashboard/header/AccountPopover.js
+++ b/src/layouts/dashboard/header/AccountPopover.js
@@ -7,7 +7,12 @@ import account from '../../../_mock/account';
 import Cookies from 'js-cookie';
 import api from 'lib/api';
 import { Link } from 'react-router-dom';
+import { atom, useRecoilState } from 'recoil';
 
+export const petState = atom({
+  key:'petImg',
+  default:''
+})
 
 // ----------------------------------------------------------------------
 
@@ -23,7 +28,9 @@ export default function AccountPopover({ isLoggedIn }) {
     setOpen(null);
   };
 
-  const [petImg, setPetImg] = useState(null);
+  const [petImg, setPetImg] = useRecoilState(petState);
+
+
 
   useEffect(() => {
     handlePetUrl()
@@ -53,7 +60,7 @@ export default function AccountPopover({ isLoggedIn }) {
             .then((res) => {
               console.log("accesstoken" + res.data.data);
               Cookies.set("key", res.data.data);
-              alert('토큰 재발급 성공');
+              //alert('토큰 재발급 성공');
             })
             .catch((err) => {
               alert('토큰 재발급 실패');

--- a/src/layouts/dashboard/nav/index.js
+++ b/src/layouts/dashboard/nav/index.js
@@ -39,7 +39,7 @@ Nav.propTypes = {
 export default function Nav({ openNav, onCloseNav }) {
   const { pathname } = useLocation();
   const [petImg, setPetImg] = useState();
-
+  const [petName, setPetName] = useState();
   const isDesktop = useResponsive('up', 'lg');
 
   useEffect(() => {
@@ -60,6 +60,7 @@ export default function Nav({ openNav, onCloseNav }) {
           .then((res) => {
             console.log("res.data " + res.data.data.petUrl)
             setPetImg(res.data.data.petUrl);
+            setPetName(res.data.data.petname);
           }).catch((error) => {
             api.post("member/reissue")
               .then((res) => {
@@ -93,7 +94,7 @@ export default function Nav({ openNav, onCloseNav }) {
 
             <Box sx={{ ml: 2 }}>
               <Typography variant="subtitle2" sx={{ color: 'text.primary' }}>
-                {account.displayName}
+                {petName}
               </Typography>
 
               <Typography variant="body2" sx={{ color: 'text.secondary' }}>

--- a/src/layouts/dashboard/nav/index.js
+++ b/src/layouts/dashboard/nav/index.js
@@ -16,6 +16,7 @@ import NavSection from '../../../components/nav-section';
 import navConfig from './config';
 import Cookies from 'js-cookie';
 import api from '../../../lib/api';
+import NavList from './navList';
 
 // ----------------------------------------------------------------------
 
@@ -105,8 +106,8 @@ export default function Nav({ openNav, onCloseNav }) {
         </Link>
       </Box>
 
-      <NavSection data={navConfig} />
-
+      {/* <NavSection data={navConfig} /> */}
+      <NavList/>
       <Box sx={{ flexGrow: 1 }} />
 
       <Box sx={{ px: 2.5, pb: 3, mt: 10 }}>

--- a/src/layouts/dashboard/nav/navList.tsx
+++ b/src/layouts/dashboard/nav/navList.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react';
+import List from '@mui/material/List';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import Collapse from '@mui/material/Collapse';
+import InboxIcon from '@mui/icons-material/MoveToInbox';
+import ExpandLess from '@mui/icons-material/ExpandLess';
+import ExpandMore from '@mui/icons-material/ExpandMore';
+import TextSnippetOutlinedIcon from '@mui/icons-material/TextSnippetOutlined';
+import PetsOutlinedIcon from '@mui/icons-material/PetsOutlined';
+import VpnKeyOutlinedIcon from '@mui/icons-material/VpnKeyOutlined';
+import DnsOutlinedIcon from '@mui/icons-material/DnsOutlined';
+import HomeOutlinedIcon from '@mui/icons-material/HomeOutlined';
+import PermIdentityOutlinedIcon from '@mui/icons-material/PermIdentityOutlined';
+
+export default function NavList() {
+    const [open, setOpen] = React.useState(true);
+    const [pet, setPet] = React.useState(true);
+
+    const handleClick = () => {
+        setOpen(!open);
+    };
+    const handlePetClick = () => {
+        setPet(!pet);
+    };
+
+    return (
+        <List
+            sx={{ width: '100%', maxWidth: 360, bgcolor: 'background.paper' }}
+            component="nav"
+            aria-labelledby="nested-list-subheader"
+        >
+            <CustomListItem href="/main" primaryText="메인" icon={<HomeOutlinedIcon />} />
+            <CustomListItem href="/main" primaryText="반려일지" icon={<PetsOutlinedIcon />} />
+            <CustomListItem href="/board" primaryText="게시판" icon={<TextSnippetOutlinedIcon />} />
+
+            <ListItemButton onClick={handleClick} sx={{ pl: 2 }}>
+                <ListItemIcon>
+                    <InboxIcon />
+                </ListItemIcon>
+                <ListItemText primary="마이페이지" />
+                {open ? <ExpandLess /> : <ExpandMore />}
+            </ListItemButton>
+
+            <Collapse in={open} timeout="auto" unmountOnExit>
+                <List component="div" disablePadding>
+                    <CustomListItem href="/member/editPw" primaryText="내 정보" icon={<PermIdentityOutlinedIcon />} plSize={4} />
+                    <CustomListItem href="/member/editPw" primaryText="비밀번호 변경" icon={<VpnKeyOutlinedIcon />} plSize={4} />
+                    <CustomListItem href="/member/editNick" primaryText="닉네임 변경" icon={<DnsOutlinedIcon />} plSize={4} />
+                </List>
+            </Collapse>
+
+            <ListItemButton onClick={handlePetClick} sx={{ pl: 2 }}>
+                <ListItemIcon>
+                    <PetsOutlinedIcon />
+                </ListItemIcon>
+                <ListItemText primary="펫" />
+                {open ? <ExpandLess /> : <ExpandMore />}
+            </ListItemButton>
+
+            <Collapse in={pet} timeout="auto" unmountOnExit>
+                <List component="div" disablePadding>
+                    <CustomListItem href="/pet/edit" primaryText="펫 수정" icon={<PetsOutlinedIcon />} plSize={4} />
+                    <CustomListItem href="/pet/petform" primaryText="펫 등록" icon={<PetsOutlinedIcon />} plSize={4} />
+                </List>
+            </Collapse>
+        </List>
+    );
+}
+
+
+//href:이동할 주소, primaryText:메뉴이름
+const CustomListItem = ({ href, primaryText, icon, plSize }: 
+    //plSize는 필수아님
+    { href: string; primaryText: string; icon: JSX.Element; plSize?: number }) => {
+    return (
+        <ListItemButton component="a" href={href} sx={{ pl: plSize ? plSize : 2}}>
+            <ListItemIcon>
+                {icon}
+            </ListItemIcon>
+            <ListItemText primary={primaryText} />
+        </ListItemButton>
+    );
+};

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -32,7 +32,6 @@ export default function DashboardAppPage() {
         </Typography>
 
         <Grid container spacing={3}>
-        <RecoilRoot>
           <Grid item xs={12} md={6} lg={4}>
             <Calendar/>
           </Grid>
@@ -40,7 +39,6 @@ export default function DashboardAppPage() {
           <Grid item xs={12} md={6} lg={8}>
             <Todofeed/>
           </Grid>
-        </RecoilRoot>
           
 
           <Grid item xs={12} md={6} lg={8}>

--- a/src/routes.js
+++ b/src/routes.js
@@ -19,6 +19,9 @@ import PetFormPage from './pages/PetFormPage';
 import MainPage from './pages/Main';
 import Logout from 'components/member/Logout';
 import SignUpPage from 'pages/SignUpPage';
+import EditNick from 'components/member/mypage/EditNick';
+import EditPw from 'components/member/mypage/EditPw';
+import PetEditPage from 'pages/PetEditPage';
 
 // ----------------------------------------------------------------------
 
@@ -65,10 +68,11 @@ export default function Router() {
       ],
     },
     {
-      path: '/petform',
+      path: '/pet',
       element: <DashboardLayout />,
       children: [
-        { element: <PetFormPage />, index: true },
+        { path: 'petform',element: <PetFormPage />},
+        { path: 'edit',element: <PetEditPage />},
       ],
     },
     {
@@ -81,6 +85,14 @@ export default function Router() {
         { path: 'modify/:boardId', element: <BoardModifyForm />},
         { path: 'list/:category', element: <BoardListPage /> },
       ],
+    },
+    {
+      path: '/member',
+      element: <DashboardLayout/>,
+      children: [
+        {element: <EditNick/>, path:'editNick' },
+        {element: <EditPw/>, path:'editPw' },
+      ]
     },
     {
       path: '*',


### PR DESCRIPTION
**1. 헤더 로고를 변경하엿습니다**

**2. 왼쪽 메뉴 상단에 펫 이름을 불러오게 하였습니다.**

**3. recoilroot 위치를 가장 최상단인 App.js로 변경하였습니다**

**4. 회원가입 및 마이페이지, 펫 페이지 레이아웃을 변경하였습니다**

- 회원가입

![image](https://github.com/PetGoorm/frontend/assets/117141532/5c10a9b3-f250-40a6-8937-343c965459a5)

- 비밀번호 변경

![image](https://github.com/PetGoorm/frontend/assets/117141532/d933aada-b7b9-4181-a811-15497e5811a2)

- 닉네임 변경(본인 닉 불러오도록 수정해야함)

![image](https://github.com/PetGoorm/frontend/assets/117141532/31597372-4038-4c92-a67a-d880971c0695)

- 펫 등록 및 수정페이지

![image](https://github.com/PetGoorm/frontend/assets/117141532/aab95aa8-c7be-4a76-b6be-821d93c7658e)
![image](https://github.com/PetGoorm/frontend/assets/117141532/7a669454-0e55-46ea-84af-c5793eba3de7)

**5. 왼쪽 메뉴바를 List 형식으로 변형하였습니다 (접었다 폈다 가능)**

![image](https://github.com/PetGoorm/frontend/assets/117141532/c3527d5e-f8af-4d16-a7c1-f7f94ebaf269)

**6. 게시판 댓글 기능을 추가하였습니다.**

- 본인이 작성한 댓글일시 수정과 삭제 이모지가 나옴

![image](https://github.com/PetGoorm/frontend/assets/117141532/b64c786b-3147-4b1e-a413-433ff1ae27d4)

**7. 회원가입시 법정동 코드를 추가로 전달하도록 변경하였습니다.**

- 기존처럼 주소를 잘라 사용하던 방법과는 달리 
   법정동 코드를 사용하여 일치하는 회원들의 글만 보이게 수정해도 좋을 것 같습니당

**수정 및 해야 할 것**

- 본인의 이메일과 주소를 확인할 수 있는 마이페이지 기능 추가(주소는 변경가능하도록)
- 닉네임 변경시 본인 닉네임 가져오도록 변경
- 댓글 페이징(후순위)
- 게시판 본인 글에만 수정, 삭제 버튼 보이도록 변경
- form형식의 페이지들에 겹치는 TextFileld 코드 함수화
- 댓글단 사람의 프로필사진을 보이게 할지 말지 고민 ☆
- 토큰 재발급하는 방법 변경


