### PR TITLE
(feat: 에러 핸들링 기능 추가)

### DIFF
--- a/src/components/member/Logout.tsx
+++ b/src/components/member/Logout.tsx
@@ -7,16 +7,21 @@ export default function Logout(){
 
     useEffect(() => {
         if (accessToken) {
-            api.post("member/logout", null)
-            .then((res)=>{
-                Cookies.remove('key');
-                alert('로그아웃 성공!')
-                return window.location.replace('/');
-            }).catch((e)=>{
-                console.log(e)
-            })
+            LogoutApi()
         } 
 
       }, [accessToken]);
     
+}
+
+export const LogoutApi = async() =>{
+    
+    try{
+        const result = await api.post('member/logout');
+        Cookies.remove('key')
+        alert('로그아웃 성공.')
+        return window.location.replace('/');
+      }catch(error){
+        console.log(error);
+      }
 }

--- a/src/layouts/dashboard/header/AccountPopover.js
+++ b/src/layouts/dashboard/header/AccountPopover.js
@@ -30,8 +30,6 @@ export default function AccountPopover({ isLoggedIn }) {
 
   const [petImg, setPetImg] = useRecoilState(petState);
 
-
-
   useEffect(() => {
     handlePetUrl()
   }, [petImg])
@@ -49,27 +47,12 @@ export default function AccountPopover({ isLoggedIn }) {
   
 
   //헤더 아바타에 들어갈 펫 이미지 
-  const handlePetUrl = () => {
+  const handlePetUrl = async () => {
     if (Cookies.get("key")) {
-      api.get("pet/petinfo")
-        .then((res) => {
-          console.log("res.data " + res.data.data.petUrl)
-          setPetImg(res.data.data.petUrl);
-        }).catch((error) => {
-          api.post("member/reissue")
-            .then((res) => {
-              console.log("accesstoken" + res.data.data);
-              Cookies.set("key", res.data.data);
-              //alert('토큰 재발급 성공');
-            })
-            .catch((err) => {
-              alert('토큰 재발급 실패');
-              console.log(err.message)
-            })
-          console.log(error.message)
-        })
-    }
+      const result = await api.get("pet/petinfo");
+      setPetImg(result.data.data.petUrl);
   }
+}
   console.log("isLoggedIn"+isLoggedIn)
 
 

--- a/src/layouts/dashboard/nav/index.js
+++ b/src/layouts/dashboard/nav/index.js
@@ -3,32 +3,18 @@ import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 // @mui
 import { styled, alpha } from '@mui/material/styles';
-import { Box, Link, Button, Drawer, Typography, Avatar, Stack } from '@mui/material';
-// mock
-import account from '../../../_mock/account';
+import { Box,Drawer, Stack } from '@mui/material';
 // hooks
 import useResponsive from '../../../hooks/useResponsive';
 // components
 import Logo from '../../../components/logo';
 import Scrollbar from '../../../components/scrollbar';
-import NavSection from '../../../components/nav-section';
-//
-import navConfig from './config';
-import Cookies from 'js-cookie';
-import api from '../../../lib/api';
 import NavList from './navList';
 
 // ----------------------------------------------------------------------
 
 const NAV_WIDTH = 280;
 
-const StyledAccount = styled('div')(({ theme }) => ({
-  display: 'flex',
-  alignItems: 'center',
-  padding: theme.spacing(2, 2.5),
-  borderRadius: Number(theme.shape.borderRadius) * 1.5,
-  backgroundColor: alpha(theme.palette.grey[500], 0.12),
-}));
 
 // ----------------------------------------------------------------------
 
@@ -39,8 +25,6 @@ Nav.propTypes = {
 
 export default function Nav({ openNav, onCloseNav }) {
   const { pathname } = useLocation();
-  const [petImg, setPetImg] = useState();
-  const [petName, setPetName] = useState();
   const isDesktop = useResponsive('up', 'lg');
 
   useEffect(() => {
@@ -49,33 +33,6 @@ export default function Nav({ openNav, onCloseNav }) {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pathname]);
-
-  useEffect(() => {
-    handlePetUrl()
-  }, [petImg])
-
-    //헤더 아바타에 들어갈 펫 이미지 
-    const handlePetUrl = () => {
-      if (Cookies.get("key")) {
-        api.get("pet/petinfo")
-          .then((res) => {
-            console.log("res.data " + res.data.data.petUrl)
-            setPetImg(res.data.data.petUrl);
-            setPetName(res.data.data.petname);
-          }).catch((error) => {
-            api.post("member/reissue")
-              .then((res) => {
-                console.log("accesstoken" + res.data.data);
-                Cookies.set("key", res.data.data);
-                console.log('토큰 재발급 성공');
-              })
-              .catch((err) => {
-                console.log(err.message)
-              })
-            console.log(error.message)
-          })
-      }
-    }
 
   const renderContent = (
     <Scrollbar
@@ -88,23 +45,6 @@ export default function Nav({ openNav, onCloseNav }) {
         <Logo />
       </Box>
 
-      <Box sx={{ mb: 5, mx: 2.5 }}>
-        <Link underline="none">
-          <StyledAccount>
-            <Avatar src={petImg} alt="photoURL" />
-
-            <Box sx={{ ml: 2 }}>
-              <Typography variant="subtitle2" sx={{ color: 'text.primary' }}>
-                {petName}
-              </Typography>
-
-              <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-                {account.role}
-              </Typography>
-            </Box>
-          </StyledAccount>
-        </Link>
-      </Box>
 
       {/* <NavSection data={navConfig} /> */}
       <NavList/>

--- a/src/lib/api.tsx
+++ b/src/lib/api.tsx
@@ -1,11 +1,12 @@
 import axios from 'axios'
+import { LogoutApi } from 'components/member/Logout';
 import Cookies from 'js-cookie';
 
 const api = axios.create({
-	baseURL : 'http://localhost:7777/',
-    headers: {
-        "Content-Type": `application/json`,
-      },
+  baseURL: 'http://localhost:7777/',
+  headers: {
+    "Content-Type": `application/json`,
+  },
 })
 
 //로그인 된 상태일때 header에 인증토큰 추가하는 인터셉터
@@ -19,5 +20,35 @@ api.interceptors.request.use((config) => {
   return config;
 });
 
+//인터셉터 -> api 요청시 response를 가로채서 미리 실행하는 도구
+api.interceptors.response.use(
+  (success) => success,
+  async (error) => {
+    const errorResponse = error.response.data;
+
+    console.log(errorResponse);
+
+    //만료된 access토큰일 경우(5001)
+    if (errorResponse.statusCode === 5001) {
+      try {
+        const result = await api.post('member/reissue');
+        console.log("accesstoken" + result.data.data);
+        Cookies.set("key", result.data.data);
+        console.log('토큰 재발급 성공');
+        //토큰 재발급 후 중단된 api 다시 실행되게 리턴
+        return api(error.config);
+
+      } catch (error) {
+        //reissue api에서 에러 발생시 refresh 토큰오류로 간주하고 강제 로그아웃
+        console.log("reissue error "+error);
+        Cookies.remove('key')
+        window.location.replace('/');
+
+      }
+
+      return Promise.reject(error);
+    } 
+  }
+);
 
 export default api

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -60,7 +60,7 @@
       // this 키워드가 any 타입일 경우 에러 발생
       "noImplicitThis": true,
       // 함수에서 return 생략 시 에러 발생
-      "noImplicitReturns": true,
+      "noImplicitReturns": false,
       // switch 문이 잘못된 경우 에러 발생
       "noFallthroughCasesInSwitch": true
     },


### PR DESCRIPTION
**1. 메뉴바에서 펫 이미지 불러오는 기능 삭제**

**2. 공통 api 함수에서 response에러를 감지하여 핸들링 하는 기능 추가**
- `api.interceptors.response.use`: response 에러 감지 인터셉터
- 백엔드단에서 보내준 에러코드가 5001일 경우 만료된  토큰으로 판단하고
- `/member/reissue`로 `access token 재발급 요청`을 보냄
- 토큰 재발급시 에러가 반환되면 `refresh token에러`로 감지하여 쿠키삭제 (강제 로그아웃 시킴)
- 만약 토큰 재발급 성공시 취소됐던 `api 요청을 다시 return` 하여 다시 기능 동작하도록 함